### PR TITLE
Feature/add regions

### DIFF
--- a/src/controller/riot.controller.js
+++ b/src/controller/riot.controller.js
@@ -138,10 +138,9 @@ export const getChampionStats = async (req, res) => {
 export const getProfile = async (req, res) => {
   try {
     const { puuid } = req.query;
-
-    const summonerData = await riotService.getSummonerByPuuid(puuid);
-    const rankedData = await riotService.getRankedBySummonerId(summonerData.id);
-
+    const summonerData = await riotService.getAccountByRiotId(puuid);
+    const rankedData = await riotService.getRankedByPuuid(summonerData.puuid);
+    
     const ranks = processRankedData(rankedData);
 
     const responseData = {
@@ -296,7 +295,7 @@ export const getChampionsList = async (req, res) => {
   try {
     const now = Date.now();
     if (!championsCache || now - lastFetch > CACHE_TTL) {
-      const version = "14.12.1"; // Ou use process.env.DDRAGON_VERSION
+      const version = "14.12.1";
       const url = `https://ddragon.leagueoflegends.com/cdn/${version}/data/pt_BR/champion.json`;
       const response = await fetch(url);
       const data = await response.json();

--- a/src/services/riot.service.js
+++ b/src/services/riot.service.js
@@ -71,7 +71,6 @@ const getBaseUrl = (service, region) => {
   return endpoints[service].americas;
 };
 
-// Exemplo de função modificada: getAccountByRiotId
 export const getAccountByRiotId = async (nome, tag, regiao = 'americas') => {
   try {
     const baseURL = getBaseUrl('riotAccount', regiao);
@@ -84,27 +83,6 @@ export const getAccountByRiotId = async (nome, tag, regiao = 'americas') => {
   } catch (error) {
     console.log('Erro ao buscar conta Riot:', error);
     throw new Error('Erro ao buscar conta Riot.');
-  }
-};
-
-/**
- * Busca os dados de um invocador pelo seu summonerId para obter o PUUID.
- */
-const getSummonerBySummonerId = async (summonerId, regiao = 'americas') => {
-  try {
-    const baseURL = getBaseUrl('summoner', regiao);
-    const res = await fetch(
-      `${baseURL}/lol/summoner/v4/summoners/${summonerId}`,
-      { headers: { "X-Riot-Token": RIOT_API_KEY } }
-    );
-    if (!res.ok) {
-      console.error(`Não foi possível buscar o perfil para o summonerId: ${summonerId}`);
-      return null;
-    }
-    return await res.json();
-  } catch (error) {
-    console.error('Erro em getSummonerBySummonerId:', error);
-    return null;
   }
 };
 
@@ -147,14 +125,7 @@ export const getChallenger = async (queue, regiao = 'americas') => {
 
     const detailedPlayers = await Promise.all(
       top3Players.map(async (player, index) => {
-        let profile = null;
-        let account = null;
-        try {
-          profile = await getSummonerBySummonerId(player.summonerId, regiao);
-          account = profile ? await getAccountByPuuid(profile.puuid, regiao) : null;
-        } catch (error) {
-          console.error(error);
-        }
+        const account = await getAccountByPuuid(player.summonerId, regiao);
         return {
           position: index + 1,
           name: account?.gameName || player.summonerName,
@@ -162,7 +133,7 @@ export const getChallenger = async (queue, regiao = 'americas') => {
           leaguePoints: player.leaguePoints,
           wins: player.wins,
           losses: player.losses,
-          puuid: profile?.puuid || ''
+          puuid: account?.puuid || ''
         };
       })
     );
@@ -257,11 +228,11 @@ export const getSummonerByPuuid = async (puuid, regiao = 'americas') => {
   }
 };
 
-export const getRankedBySummonerId = async (summonerId, regiao = 'americas') => {
+export const getRankedByPuuid = async (puuid, regiao = 'americas') => {
   try {
     const baseURL = getBaseUrl('summoner', regiao);
     const res = await fetch(
-      `${baseURL}/lol/league/v4/entries/by-summoner/${summonerId}`,
+      `${baseURL}/lol/league/v4/entries/by-puuid/${puuid}`,
       { headers: { "X-Riot-Token": RIOT_API_KEY } }
     );
     if (!res.ok) return [];


### PR DESCRIPTION
### Melhorias no Tratamento de Regiões:
* Adicionada a função auxiliar `getBaseUrl` para mapear dinamicamente os endpoints dos serviços com base nos clusters (Américas, Europa, Ásia) e códigos de região. Isso centraliza a lógica de regiões e reduz mapeamentos fixos. (riot.service.js)

### Transição para Métodos Baseados em PUUID:
* Substituídos os métodos baseados em Summoner ID (`getSummonerBySummonerId` e `getRankedBySummonerId`) pelos métodos `getAccountByPuuid` e `getRankedByPuuid`, padronizando a recuperação dos dados utilizando PUUIDs em vez de Summoner IDs. ([1](diffhunk://#diff-26ba1848350475a5d6e5483534215d54835d8b2f7ca5d8b35466fc0c1b49b88cL39-R94) [2](diffhunk://#diff-26ba1848350475a5d6e5483534215d54835d8b2f7ca5d8b35466fc0c1b49b88cL218-R235))
* Atualizado o método `getChallenger` para buscar diretamente os detalhes da conta usando PUUID, simplificando a lógica e removendo a recuperação intermediária do perfil do invocador. (riot.service.js)

### Atualizações nos Endpoints:
* Ajustados todos os métodos (`getChampionMastery`, `getMatchIds`, `getMatchById`, `getSummonerByPuuid`) para utilizar a nova função `getBaseUrl`, garantindo a consistência na construção das URLs com base na região. ([1](diffhunk://#diff-26ba1848350475a5d6e5483534215d54835d8b2f7ca5d8b35466fc0c1b49b88cL147-R160) [2](diffhunk://#diff-26ba1848350475a5d6e5483534215d54835d8b2f7ca5d8b35466fc0c1b49b88cL175-R188) [3](diffhunk://#diff-26ba1848350475a5d6e5483534215d54835d8b2f7ca5d8b35466fc0c1b49b88cL190-R203) [4](diffhunk://#diff-26ba1848350475a5d6e5483534215d54835d8b2f7ca5d8b35466fc0c1b49b88cL205-R220))

### Ajustes no Controller:
* Atualizado o método `getProfile` em `riot.controller.js` para utilizar `getAccountByRiotId` e `getRankedByPuuid`, alinhando-o com a nova abordagem baseada em PUUID. (riot.controller.js)

### Limpeza de Código:
* Removido código e comentários não utilizados, como a lógica redundante baseada em summoner e anotações desatualizadas. ([1](diffhunk://#diff-26ba1848350475a5d6e5483534215d54835d8b2f7ca5d8b35466fc0c1b49b88cL39-R94) [2](diffhunk://#diff-26ba1848350475a5d6e5483534215d54835d8b2f7ca5d8b35466fc0c1b49b88cL100-L127))